### PR TITLE
Added support for Spotlight Emitters

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ To use it, copy the file 'io_nori.py' into the addons/ folder of your blender in
 - By enabling the option "Export textures", the exporter adds a texture to your BSDF entry if available. Note that only image textures are supported atm. If no texture is found, the default BSDF color is exported. To use this feature, add an Image Texture Node and connect it to the "Color" or "Base Color" socket of your object. The path to the image will be copied relative to the blender file for now, so if you want to use the output right away save the XML in the same folder as the blender file.
 - The checkbox "Export OBJ in world coords" defines how your obj files are exported: If enabled, we export the mesh in world coordinates of Blender. Otherwise, we export the mesh in local coordinates and add a toWorld transform to the XML entry.
 - The checkbox "Triangular Mesh" exports all your meshes as triangular meshes. This is helpful if your mesh has complex polygons that Nori does not support. Note that after this export your mesh in Blender stays triangular.
+- The checkbox "True Spheres" defines all meshes with "Sphere" in their name as a sphere with infinite faces in the XML, instead of creating an .obj file.
 - The "Number of Camera Rays" input box sets the sampleCount parameter of your sampler.
 
 ## Disclaimer

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To use it, copy the file 'io_nori.py' into the addons/ folder of your blender in
 
 - Only "visible" objects are exported, so by switching the eye icon of your objects on/off you can decide what to export.
 - Object instances are also supported. The exporter silently unrolls the instances into a single mesh, exports it and sets it back to the state before.
-- By enabling the option "Export lights", the exporter will export : Point Lights as point lights and Objects with a "Emission" BSDF as area lights. Thus, you can export mesh area lights to Nori. Note: For now Blender area lights are not exported (they only support simple geometry). When "Export lights" is selected, the default integrator is "path_mis", otherwise "normals".
+- By enabling the option "Export lights", the exporter will export : Point Lights as point lights, Spot Lights as spot lights and Objects with a "Emission" BSDF as area lights. Thus, you can export mesh area lights to Nori. Note: For now Blender area lights are not exported (they only support simple geometry). When "Export lights" is selected, the default integrator is "path_mis", otherwise "normals".
 - By enabling the option "Export BSDF properties", the exporter will export the mesh and add a translated BSDF entry to the xml file for this object (multiple materials for different faces of a single object are also supported). Otherwise, a diffuse BSDF with the viewport color of the object is added to the XML. The following translations are currently available:
     - Principled BSDF -> disney
     - Diffuse BSDF -> diffuse

--- a/io_nori.py
+++ b/io_nori.py
@@ -194,6 +194,29 @@ class NoriWriter:
                     color[2] *=power
                     pointLight.appendChild(self.__createEntry("color", "power", "%f,%f,%f"%(color[0], color[1], color[2])))
                     self.scene.appendChild(pointLight)
+                elif(source.data.type == "SPOT"):
+                    spotLight = self.__createElement("emitter", {"type" : "spot"})
+
+                    pos = source.location
+                    spotLight.appendChild(self.__createEntry("point", "position", "%f,%f,%f"%(pos.x,pos.y,pos.z)))
+
+                    dir =  source.matrix_world.to_quaternion() @ Vector((0.0, 0.0, -1.0))
+                    spotLight.appendChild(self.__createEntry("vector", "direction", "%f,%f,%f"%(dir.x,dir.y,dir.z)))
+
+                    power = source.data.energy
+                    color = list(source.data.color).copy()
+                    color[0] *=power
+                    color[1] *=power
+                    color[2] *=power
+                    spotLight.appendChild(self.__createEntry("color", "power", "%f,%f,%f"%(color[0], color[1], color[2])))
+
+                    cutoff_angle = source.data.spot_size / 2 # radians
+                    spotLight.appendChild(self.__createEntry("float", "cutoff_angle", "%f"%cutoff_angle))
+
+                    falloff_angle = cutoff_angle * (1 - source.data.spot_blend) # also radians
+                    spotLight.appendChild(self.__createEntry("float", "falloff_angle", "%f"%falloff_angle))
+
+                    self.scene.appendChild(spotLight)
                 else:
                     self.verbose("WARN: Light source type (%s) is not supported" % source.data.type)
 


### PR DESCRIPTION
fixes #2 

added support for spotlight emitters. example of a spotlight generated in xml format:
```
<emitter type="spot">
		<point name="position" value="0.000000,-7.562405,11.619473"/>
		<vector name="direction" value="0.000000,0.485355,-0.874317"/>
		<color name="power" value="10000.000000,759.987459,967.895240"/>
		<float name="cutoff_angle" value="8.300002"/>
		<float name="falloff_angle" value="1.245000"/>
</emitter>
```